### PR TITLE
Shortcode formatting/wpautop handling

### DIFF
--- a/athena-shortcodes.php
+++ b/athena-shortcodes.php
@@ -42,7 +42,8 @@ if ( ! function_exists( 'athena_sc_init' ) ) {
 		// Add our preconfigured shortcodes.
 		add_action( 'athena_sc_add_shortcode', array( 'ATHENA_SC_Config', 'athena_sc_add_shortcode' ), 10, 1 );
 		// Add out shortcodes to the no_texturized list
-		//add_action( 'no_texturize_shortcodes', array( 'ATHENA_SC_Config', 'no_texturize' ), 10, 1 );
+		// add_action( 'no_texturize_shortcodes', array( 'ATHENA_SC_Config', 'no_texturize' ), 10, 1 );
+		add_filter( 'the_content', array( 'ATHENA_SC_Config', 'format_shortcode_output' ), 10, 1 );
 		// Register our shortcodes.
 		add_action( 'init', array( 'ATHENA_SC_Config', 'register_shortcodes' ) );
 
@@ -56,8 +57,9 @@ if ( ! function_exists( 'athena_sc_init' ) ) {
 		// add_filter( 'the_content', 'wpautop' , 99);
 		// add_filter( 'the_content', 'shortcode_unautop',100 );
 
-		add_filter('the_content', 'do_shortcode', 9);
-		add_filter('widget_text', 'do_shortcode', 9);
+		// add_filter('the_content', 'do_shortcode', 9);
+		// add_filter('widget_text', 'do_shortcode', 9);
+		add_filter( 'widget_text', 'do_shortcode' );
 	}
 
 	add_action( 'plugins_loaded', 'athena_sc_init' );

--- a/athena-shortcodes.php
+++ b/athena-shortcodes.php
@@ -41,8 +41,8 @@ if ( ! function_exists( 'athena_sc_init' ) ) {
 	function athena_sc_init() {
 		// Add our preconfigured shortcodes.
 		add_action( 'athena_sc_add_shortcode', array( 'ATHENA_SC_Config', 'athena_sc_add_shortcode' ), 10, 1 );
-		// Add out shortcodes to the no_texturized list
-		// add_action( 'no_texturize_shortcodes', array( 'ATHENA_SC_Config', 'no_texturize' ), 10, 1 );
+		// Update the_content to strip excess <p></p> and <br> insertion around
+		// Athena shortcodes.
 		add_filter( 'the_content', array( 'ATHENA_SC_Config', 'format_shortcode_output' ), 10, 1 );
 		// Register our shortcodes.
 		add_action( 'init', array( 'ATHENA_SC_Config', 'register_shortcodes' ) );
@@ -52,13 +52,7 @@ if ( ! function_exists( 'athena_sc_init' ) ) {
 			add_action( 'wp_scif_add_shortcode', array( 'ATHENA_SC_Config', 'register_shortcodes_interface' ), 10, 1 );
 		}
 
-
-		// remove_filter( 'the_content', 'wpautop' );
-		// add_filter( 'the_content', 'wpautop' , 99);
-		// add_filter( 'the_content', 'shortcode_unautop',100 );
-
-		// add_filter('the_content', 'do_shortcode', 9);
-		// add_filter('widget_text', 'do_shortcode', 9);
+		// Allow shortcodes within text widgets.
 		add_filter( 'widget_text', 'do_shortcode' );
 	}
 

--- a/includes/athena-sc-config.php
+++ b/includes/athena-sc-config.php
@@ -41,7 +41,7 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 			);
 		}
 
-		public static function no_texturize( $shortcodes ) {
+		public static function no_texturize( $shortcodes=array() ) {
 			$installed = self::installed_shortcodes();
 
 			foreach( $installed as $shortcode ) {
@@ -49,6 +49,19 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 			}
 
 			return $shortcodes;
+		}
+
+		/**
+		 * Strip out <p></p> and <br> from inner shortcode contents. Applied
+		 * only to shortcodes returned by ATHENA_SC_Config::no_texturize().
+		 *
+		 * https://wordpress.stackexchange.com/a/130185
+		 **/
+		public static function format_shortcode_output( $content ) {
+			$block = join( '|', self::no_texturize() );
+			$rep = preg_replace( "/(<p>)?\[($block)(\s[^\]]+)?\](<\/p>|<br \/>)?/", "[$2$3]", $content );
+			$rep = preg_replace( "/(<p>)?\[\/($block)](<\/p>|<br \/>)?/", "[/$2]", $rep );
+			return $rep;
 		}
 	}
 }

--- a/includes/athena-sc-config.php
+++ b/includes/athena-sc-config.php
@@ -55,7 +55,8 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 
 		/**
 		 * Strip out <p></p> and <br> from inner shortcode contents. Applied
-		 * only to shortcodes returned by the athena_sc_get_shortcodes hook.
+		 * only to shortcodes returned by the
+		 * athena_sc_get_formatted_shortcodes hook.
 		 *
 		 * https://wordpress.stackexchange.com/a/130185
 		 **/

--- a/includes/athena-sc-config.php
+++ b/includes/athena-sc-config.php
@@ -26,7 +26,9 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 		}
 
 		public static function installed_shortcodes() {
-			$installed = apply_filters( 'athena_sc_add_shortcode', array( 'ATHENA_SC_Config', 'athena_sc_add_shortcode' ) );
+			// Get shortcodes via the `athena_sc_add_shortcode` hook.
+			$installed = self::athena_sc_add_shortcode();
+			$installed = apply_filters( 'athena_sc_add_shortcode', $installed );
 
 			return array_map( create_function( '$class', '
 				return new $class;
@@ -41,7 +43,7 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 			);
 		}
 
-		public static function no_texturize( $shortcodes=array() ) {
+		public static function athena_sc_get_formatted_shortcodes() {
 			$installed = self::installed_shortcodes();
 
 			foreach( $installed as $shortcode ) {
@@ -53,12 +55,16 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 
 		/**
 		 * Strip out <p></p> and <br> from inner shortcode contents. Applied
-		 * only to shortcodes returned by ATHENA_SC_Config::no_texturize().
+		 * only to shortcodes returned by the athena_sc_get_shortcodes hook.
 		 *
 		 * https://wordpress.stackexchange.com/a/130185
 		 **/
 		public static function format_shortcode_output( $content ) {
-			$block = join( '|', self::no_texturize() );
+			// Get shortcodes via the `athena_sc_get_formatted_shortcodes` hook.
+			$shortcodes = self::athena_sc_get_formatted_shortcodes();
+			$shortcodes = apply_filters( 'athena_sc_get_formatted_shortcodes', $shortcodes );
+
+			$block = join( '|', $shortcodes );
 			$rep = preg_replace( "/(<p>)?\[($block)(\s[^\]]+)?\](<\/p>|<br \/>)?/", "[$2$3]", $content );
 			$rep = preg_replace( "/(<p>)?\[\/($block)](<\/p>|<br \/>)?/", "[/$2]", $rep );
 			return $rep;


### PR DESCRIPTION
Adds a `the_content` filter for Athena shortcodes to prevent unwanted insertion of `<p></p>` and `<br>` tags around shortcode output.

The method used avoids modifications to other shortcodes not explicitly returned via the `athena_sc_get_formatted_shortcodes` hook, doesn't modify the execution order of `the_content` actions, and allows for extension by other plugins if desired.  https://wordpress.stackexchange.com/a/130185