### PR TITLE
Buttons

### DIFF
--- a/includes/athena-sc-config.php
+++ b/includes/athena-sc-config.php
@@ -37,7 +37,8 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 			return array(
 				'ContainerSC',
 				'RowSC',
-				'ColSC'
+				'ColSC',
+				'ButtonSC'
 			);
 		}
 

--- a/shortcodes/sc-button.php
+++ b/shortcodes/sc-button.php
@@ -51,12 +51,42 @@ if ( ! class_exists( 'ButtonSC' ) ) {
 					'name'    => 'Inline Styles',
 					'desc'    => 'Any additional styles for the button.',
 					'type'    => 'text'
+				),
+				array(
+					'param'   => 'data_toggle',
+					'name'    => 'Data-Toggle',
+					'desc'    => 'Type of toggling functionality the button should have. Use the [modal-toggle], [collapse-toggle], [popover] or [tooltip] shortcodes to create toggles for those components instead of the [button] shortcode.',
+					'type'    => 'select',
+					'options' => $this->data_toggle_options()
+				),
+				array(
+					'param'   => 'data_dismiss',
+					'name'    => 'Data-Dismiss',
+					'desc'    => 'Parent element that should be dismissed/closed when the button is clicked.',
+					'type'    => 'select',
+					'options' => $this->data_dismiss_options()
 				)
 			);
 		}
 
+		public function data_toggle_options() {
+			return array(
+				''         => '---',
+				'button'   => 'button',
+				'dropdown' => 'dropdown'
+			);
+		}
+
+		public function data_dismiss_options() {
+			return array(
+				''         => '---',
+				'alert'    => 'alert',
+				'modal'    => 'modal'
+			);
+		}
+
 		/**
-		 * Wraps content inside of a div with class .container
+		 * Wraps content inside of a link with class .btn
 		 **/
 		public function callback( $atts, $content='' ) {
 			$atts = shortcode_atts( $this->defaults(), $atts );
@@ -84,6 +114,14 @@ if ( ! class_exists( 'ButtonSC' ) ) {
 				$attributes[] = 'aria-disabled="true"';
 				$attributes[] = 'tabindex="-1"';
 				$attributes[] = 'onclick="return false;"';
+			}
+
+			// Get any data-attributes, if applicable
+			if ( $atts['data_toggle'] && in_array( $atts['data_toggle'], $this->data_toggle_options() ) ) {
+				$attributes[] = 'data-toggle="' . $atts['data_toggle'] . '"';
+			}
+			if ( $atts['data_dismiss'] && in_array( $atts['data_dismiss'], $this->data_dismiss_options() ) ) {
+				$attributes[] = 'data-dismiss="' . $atts['data_dismiss'] . '"';
 			}
 
 			// Set the button's "role" attribute if it has no href value (we

--- a/shortcodes/sc-button.php
+++ b/shortcodes/sc-button.php
@@ -42,7 +42,7 @@ if ( ! class_exists( 'ButtonSC' ) ) {
 				),
 				array(
 					'param'   => 'id',
-					'name'    => 'CSS ID',
+					'name'    => 'ID',
 					'desc'    => 'ID attribute for the button. Must be unique.',
 					'type'    => 'text'
 				),

--- a/shortcodes/sc-button.php
+++ b/shortcodes/sc-button.php
@@ -20,11 +20,11 @@ if ( ! class_exists( 'ButtonSC' ) ) {
 		 **/
 		public function fields() {
 			return array(
-                array(
+				array(
 					'param'   => 'href',
 					'name'    => 'Button Link',
 					'type'    => 'text',
-                    'default' => '#'
+					'default' => '#'
 				),
 				array(
 					'param'   => 'type',
@@ -32,46 +32,58 @@ if ( ! class_exists( 'ButtonSC' ) ) {
 					'desc'    => 'Specify the type of button to use.  Solid buttons are used by default.',
 					'type'    => 'select',
 					'options' => array(
-						'btn-' => 'Solid (default)',
-						'btn-outline-' => 'Outline',
-                        'btn-outline-i-' => 'Inverse outline'
+						'solid' => 'Solid (default)',
+						'outline' => 'Outline',
+						'outline-inverse' => 'Inverse outline'
 					),
-                    'default' => 'btn-'
+					'default' => 'solid'
 				),
-                array(
+				array(
 					'param'   => 'color',
 					'name'    => 'Button Color',
 					'desc'    => 'Specify the button color.  "Primary" buttons are used by default.  Note that not all colors are compatible with all button types.',
 					'type'    => 'select',
 					'options' => array(
-						'default'       => 'White with gray outline (-default)',
 						'primary'       => 'Gold (-primary)',
-                        'secondary'     => 'Black (-secondary)',
-                        'inverse'       => 'White (-inverse)',
-                        'link'          => 'Unstyled link',
-                        'complementary' => 'Blue (-complementary)',
-                        'success'       => 'Green (-success)',
-                        'info'          => 'Light Blue (-info)',
-                        'warning'       => 'Orange (-warning)',
-                        'danger'        => 'Red (-danger)'
+						'default'       => 'White with gray outline (-default)',
+						'secondary'     => 'Black (-secondary)',
+						'inverse'       => 'White (-inverse)',
+						'link'          => 'Unstyled link',
+						'complementary' => 'Blue (-complementary)',
+						'success'       => 'Green (-success)',
+						'info'          => 'Light Blue (-info)',
+						'warning'       => 'Orange (-warning)',
+						'danger'        => 'Red (-danger)'
 					),
-                    'default' => 'primary'
+					'default' => 'primary'
 				),
-                array(
+				array(
 					'param'   => 'size',
 					'name'    => 'Button Size',
 					'desc'    => 'Specify a size override for the button.',
 					'type'    => 'select',
 					'options' => array(
-						'btn-sm' => 'Small',
-						'btn-lg-' => 'Large'
+						''   => '---',
+						'sm' => 'Small',
+						'lg' => 'Large'
 					)
 				),
-                array(
+				array(
 					'param'   => 'block',
 					'name'    => 'Block-level Button',
 					'desc'    => 'When checked, the generated button will be block-level (and span the full width of its parent).',
 					'type'    => 'checkbox'
+				),
+				array(
+					'param'   => 'state',
+					'name'    => 'Button State',
+					'desc'    => 'Specify whether the button should have a default state on load.',
+					'type'    => 'select',
+					'options' => array(
+						''   => '---',
+						'active'   => 'Active',
+						'disabled' => 'Disabled'
+					)
 				),
 				array(
 					'param'   => 'class',
@@ -83,12 +95,6 @@ if ( ! class_exists( 'ButtonSC' ) ) {
 					'name'    => 'Inline Styles',
 					'desc'    => 'Any additional styles for the button.',
 					'type'    => 'text'
-				),
-                array(
-					'param'   => 'attributes',
-					'name'    => 'Extra attributes',
-					'desc'    => 'Any additional attributes for the button\'s <code>&lt;a&gt;</code> tag.',
-					'type'    => 'text'
 				)
 			);
 		}
@@ -99,15 +105,73 @@ if ( ! class_exists( 'ButtonSC' ) ) {
 		public function callback( $atts, $content='' ) {
 			$atts = shortcode_atts( $this->defaults(), $atts );
 
-            $href = $atts['href'];
-			$classes = array( 'btn' );
-			// ...
+			$href = $atts['href'];
 			$styles = $atts['style'] ?: false;
-            $attributes = isset( $atts['attributes'] ) ? $atts['attributes'] : false; // TODO sanitize me cap'n!
+			$attributes = array();
+			$classes = array( 'btn' );
+
+			// Get the color variant class
+			$variant_class = 'btn-';
+			switch ( $atts['type'] ) {
+				case 'outline':
+					$variant_class .= 'outline-';
+					break;
+				case 'outline-inverse':
+					$variant_class .= 'outline-i-';
+				case 'solid':
+				default:
+					break;
+			}
+			$variant_class .= $atts['color'];
+			$classes[] = $variant_class;
+
+			// Get the size class, if applicable
+			if ( $atts['size'] ) {
+				$classes[] = 'btn-' . $atts['size'];
+			}
+
+			// Get the block-level btn class, if applicable
+			if ( $atts['block'] && filter_var( $atts['block'], FILTER_VALIDATE_BOOLEAN ) ) {
+				$classes[] = 'btn-block';
+			}
+
+			// Get any other additional classes
+			if ( $atts['class'] ) {
+				$classes[] = $atts['class'];
+			}
+
+			// Get any state-related classes and attributes, if applicable
+			switch ( $atts['state'] ) {
+				case 'active':
+					$classes[] = 'active';
+					$attributes[] = 'aria-pressed="true"';
+					break;
+				case 'disabled':
+					$classes[] = 'disabled';
+					$attributes[] = 'aria-disabled="true"';
+					$attributes[] = 'tabindex="-1"';
+					$attributes[] = 'onclick="return false;"';
+					break;
+				case '':
+				default:
+					break;
+			}
+
+			// Set the button's "role" attribute if it has no href value (we
+			// assume its functionality is added via javascript somewhere.)
+			// Otherwise, we assume the button should assume its default role
+			// of being a basic link.
+			if ( $href == '' || $href == '#' ) {
+				$attributes[] = 'role="button"';
+			}
 
 			ob_start();
 		?>
-			<a href="<?php echo $href; ?>" class="<?php echo implode( $classes, ' ' ); ?>" <?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?> <?php if ( $attributes ) { echo $attributes; } ?>>
+			<a href="<?php echo $href; ?>"
+			class="<?php echo implode( $classes, ' ' ); ?>"
+			<?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?>
+			<?php if ( $attributes ) { echo implode( $attributes, ' ' ); } ?>
+			>
 				<?php echo do_shortcode( $content ); ?>
 			</a>
 		<?php

--- a/shortcodes/sc-button.php
+++ b/shortcodes/sc-button.php
@@ -96,8 +96,8 @@ if ( ! class_exists( 'ButtonSC' ) ) {
 
 			ob_start();
 		?>
-			<a href="<?php echo $href; ?>"
-			class="<?php echo implode( ' ', $classes ); ?>"
+			<a class="<?php echo implode( ' ', $classes ); ?>"
+			<?php if ( $href ) { echo 'href="' . $href . '"'; } ?>
 			<?php if ( $id ) { echo 'id="' . $id . '"'; } ?>
 			<?php if ( $new_window ) { echo 'target="_blank"'; } ?>
 			<?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?>

--- a/shortcodes/sc-button.php
+++ b/shortcodes/sc-button.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Provides a shortcode for the .container class
+ **/
+if ( ! class_exists( 'ButtonSC' ) ) {
+	class ButtonSC extends ATHENA_SC_Shortcode {
+		public
+			$command = 'button',
+			$name = 'Button',
+			$desc = 'Creates a new link styled as an Athena button.',
+			$content = true;
+
+		/**
+		 * Returns the shortcode's fields.
+		 *
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 *
+		 * @return Array | The shortcode's fields.
+		 **/
+		public function fields() {
+			return array(
+                array(
+					'param'   => 'href',
+					'name'    => 'Button Link',
+					'type'    => 'text',
+                    'default' => '#'
+				),
+				array(
+					'param'   => 'type',
+					'name'    => 'Button Type',
+					'desc'    => 'Specify the type of button to use.  Solid buttons are used by default.',
+					'type'    => 'select',
+					'options' => array(
+						'btn-' => 'Solid (default)',
+						'btn-outline-' => 'Outline',
+                        'btn-outline-i-' => 'Inverse outline'
+					),
+                    'default' => 'btn-'
+				),
+                array(
+					'param'   => 'color',
+					'name'    => 'Button Color',
+					'desc'    => 'Specify the button color.  "Primary" buttons are used by default.  Note that not all colors are compatible with all button types.',
+					'type'    => 'select',
+					'options' => array(
+						'default'       => 'White with gray outline (-default)',
+						'primary'       => 'Gold (-primary)',
+                        'secondary'     => 'Black (-secondary)',
+                        'inverse'       => 'White (-inverse)',
+                        'link'          => 'Unstyled link',
+                        'complementary' => 'Blue (-complementary)',
+                        'success'       => 'Green (-success)',
+                        'info'          => 'Light Blue (-info)',
+                        'warning'       => 'Orange (-warning)',
+                        'danger'        => 'Red (-danger)'
+					),
+                    'default' => 'primary'
+				),
+                array(
+					'param'   => 'size',
+					'name'    => 'Button Size',
+					'desc'    => 'Specify a size override for the button.',
+					'type'    => 'select',
+					'options' => array(
+						'btn-sm' => 'Small',
+						'btn-lg-' => 'Large'
+					)
+				),
+                array(
+					'param'   => 'block',
+					'name'    => 'Block-level Button',
+					'desc'    => 'When checked, the generated button will be block-level (and span the full width of its parent).',
+					'type'    => 'checkbox'
+				),
+				array(
+					'param'   => 'class',
+					'name'    => 'CSS Classes',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'style',
+					'name'    => 'Inline Styles',
+					'desc'    => 'Any additional styles for the button.',
+					'type'    => 'text'
+				),
+                array(
+					'param'   => 'attributes',
+					'name'    => 'Extra attributes',
+					'desc'    => 'Any additional attributes for the button\'s <code>&lt;a&gt;</code> tag.',
+					'type'    => 'text'
+				)
+			);
+		}
+
+		/**
+		 * Wraps content inside of a div with class .container
+		 **/
+		public function callback( $atts, $content='' ) {
+			$atts = shortcode_atts( $this->defaults(), $atts );
+
+            $href = $atts['href'];
+			$classes = array( 'btn' );
+			// ...
+			$styles = $atts['style'] ?: false;
+            $attributes = isset( $atts['attributes'] ) ? $atts['attributes'] : false; // TODO sanitize me cap'n!
+
+			ob_start();
+		?>
+			<a href="<?php echo $href; ?>" class="<?php echo implode( $classes, ' ' ); ?>" <?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?> <?php if ( $attributes ) { echo $attributes; } ?>>
+				<?php echo do_shortcode( $content ); ?>
+			</a>
+		<?php
+			return ob_get_clean();
+		}
+	}
+}

--- a/shortcodes/sc-col.php
+++ b/shortcodes/sc-col.php
@@ -185,8 +185,8 @@ if ( ! class_exists( 'ColSC' ) ) {
 		public function callback( $atts, $content='' ) {
 			$atts = shortcode_atts( $this->defaults(), $atts );
 
-			$classes  = array( isset( $atts['class'] ) ? $atts['class'] : '' );
-			$styles   = isset( $atts['style'] ) ? $atts['style'] : false;
+			$classes  = array( $atts['class'] ?: '' );
+			$styles   = $atts['style'] ?: false;
 			$prefixes = array( 'xs', 'sm', 'md', 'lg', 'xl' );
 			$suffixes = array( '', '_offset', '_pull', '_push' );
 
@@ -195,7 +195,7 @@ if ( ! class_exists( 'ColSC' ) ) {
 					$field_key = $prefix.$suffix;
 					$field_val = $atts[$field_key];
 
-					if ( isset( $field_val ) && $field_val !== '' ) {
+					if ( $field_val && $field_val !== '' ) {
 						$modifier   = str_replace( '_', '', $suffix );
 						$breakpoint = $prefix == 'xs' ? '' : '-' . $prefix;
 						$size       = ( in_array( $field_val, array( '', '12', 'none' ), true ) ) ? '' : '-' . $field_val;

--- a/shortcodes/sc-container.php
+++ b/shortcodes/sc-container.php
@@ -51,11 +51,11 @@ if ( ! class_exists( 'ContainerSC' ) ) {
 			$atts = shortcode_atts( $this->defaults(), $atts );
 
 			$classes = array();
-			$classes[] = ( isset( $atts['type'] ) && $atts['type'] ) ? $atts['type'] : 'container';
-			if ( isset( $atts['class'] ) && $atts['class'] ) {
+			$classes[] = $atts['type'] ?: 'container';
+			if ( $atts['class'] ) {
 				$classes[] = $atts['class'];
 			}
-			$styles = isset( $atts['style'] ) ? $atts['style'] : false;
+			$styles = $atts['style'] ?: false;
 
 			ob_start();
 		?>

--- a/shortcodes/sc-row.php
+++ b/shortcodes/sc-row.php
@@ -47,13 +47,13 @@ if ( ! class_exists( 'RowSC' ) ) {
 			$atts = shortcode_atts( $this->defaults(), $atts );
 
 			$classes = array( 'row' );
-			if ( isset( $atts['no_gutters'] ) && filter_var( $atts['no_gutters'], FILTER_VALIDATE_BOOLEAN ) ) {
+			if ( $atts['no_gutters'] && filter_var( $atts['no_gutters'], FILTER_VALIDATE_BOOLEAN ) ) {
 				$classes[] = 'no-gutters';
 			}
-			if ( isset( $atts['class'] ) && $atts['class'] ) {
+			if ( $atts['class'] ) {
 				$classes[] = $atts['class'];
 			}
-			$styles = isset( $atts['style'] ) ? $atts['style'] : false;
+			$styles = $atts['style'] ?: false;
 
 			ob_start();
 		?>

--- a/shortcodes/shortcodes.php
+++ b/shortcodes/shortcodes.php
@@ -5,3 +5,5 @@
 include_once 'sc-container.php';
 include_once 'sc-row.php';
 include_once 'sc-col.php';
+
+include_once 'sc-button.php';


### PR DESCRIPTION
Adds a new shortcode for Athena buttons.  Button customization is applied via the `class` attribute.

Also removes some unneeded `isset()` checks in other shortcodes (`$this->defaults()` will always at least return an empty string for each attribute, so `isset()` will always be true).