### PR TITLE
Navs

### DIFF
--- a/includes/athena-sc-config.php
+++ b/includes/athena-sc-config.php
@@ -45,7 +45,9 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 				'JumbotronSC',
 				'NavSC',
 				'NavItemSC',
-				'NavLinkSC'
+				'NavLinkSC',
+				'TabContentSC',
+				'TabPaneSC'
 			);
 		}
 

--- a/includes/athena-sc-config.php
+++ b/includes/athena-sc-config.php
@@ -40,7 +40,10 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 				'ContainerSC',
 				'RowSC',
 				'ColSC',
-				'BadgeSC'
+				'BadgeSC',
+				'NavSC',
+				'NavItemSC',
+				'NavLinkSC'
 			);
 		}
 

--- a/includes/class-shortcode.php
+++ b/includes/class-shortcode.php
@@ -47,9 +47,10 @@ if ( ! class_exists( 'ATHENA_SC_Shortcode' ) ) {
 		 * @author Jim Barnes
 		 * @since 1.0.0
 		 *
-		 * @return Array | An array of default values.
+		 * @param $param String | Optional, single shortcode param that a default value should be returned for.
+		 * @return Mixed | An array of default values, or a single param's default value (if $param is set).
 		 **/
-		public function defaults() {
+		public function defaults( $param=null ) {
 			$retval = array();
 			$fields = $this->fields();
 
@@ -60,6 +61,10 @@ if ( ! class_exists( 'ATHENA_SC_Shortcode' ) ) {
 				else {
 					$retval[$field['param']] = '';
 				}
+			}
+
+			if ( $param && isset( $retval[$param] ) ) {
+				$retval = $retval[$param];
 			}
 
 			return $retval;

--- a/shortcodes/sc-badge.php
+++ b/shortcodes/sc-badge.php
@@ -54,7 +54,7 @@ if ( ! class_exists( 'BadgeSC' ) ) {
 		}
 
 		/**
-		 * Wraps content inside of a div with class .container
+		 * Wraps content inside of a span or link with class .badge
 		 **/
 		public function callback( $atts, $content='' ) {
 			$atts = shortcode_atts( $this->defaults(), $atts );

--- a/shortcodes/sc-nav.php
+++ b/shortcodes/sc-nav.php
@@ -13,7 +13,7 @@ if ( ! class_exists( 'NavSC' ) ) {
 		/**
 		 * Returns the shortcode's fields.
 		 *
-		 * @author Jim Barnes
+		 * @author Jo Dickson
 		 * @since 1.0.0
 		 *
 		 * @return Array | The shortcode's fields.
@@ -36,8 +36,14 @@ if ( ! class_exists( 'NavSC' ) ) {
 				array(
 					'param'   => 'style',
 					'name'    => 'Inline Styles',
-					'desc'    => 'Any additional styles for the container.',
+					'desc'    => 'Any additional styles for the nav.',
 					'type'    => 'text'
+				),
+				array(
+					'param'   => 'tablist',
+					'name'    => 'Controls Tab Panes',
+					'desc'    => 'Check this checkbox if the nav contains links that toggle tab panes when clicked. Applies role="tablist" to the generated nav element.',
+					'type'    => 'checkbox'
 				)
 			);
 		}
@@ -56,14 +62,22 @@ if ( ! class_exists( 'NavSC' ) ) {
 		public function callback( $atts, $content='' ) {
 			$atts = shortcode_atts( $this->defaults(), $atts );
 
-			$styles  = $atts['style'];
-			$classes = array_unique( array_merge( array( 'nav' ), explode( ' ', $atts['class'] ) ) );
-			$elem    = in_array( $atts['element_type'], $this->element_type_options() ) ? $atts['element_type'] : $this->defaults( 'element_type' );
+			$styles     = $atts['style'];
+			$classes    = array_unique( array_merge( array( 'nav' ), explode( ' ', $atts['class'] ) ) );
+			$elem       = in_array( $atts['element_type'], $this->element_type_options() ) ? $atts['element_type'] : $this->defaults( 'element_type' );
+			$tablist    = filter_var( $atts['tablist'], FILTER_VALIDATE_BOOLEAN );
+			$attributes = array();
+
+			// Set the "role" attribute, if applicable
+			if ( $tablist ) {
+				$attributes[] = 'role="tablist"';
+			}
 
 			ob_start();
 		?>
 			<<?php echo $elem; ?> class="<?php echo implode( ' ', $classes ); ?>"
 			<?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?>
+			<?php if ( $attributes ) { echo implode( ' ', $attributes ); } ?>
 			>
 				<?php echo do_shortcode( $content ); ?>
 			</<?php echo $elem; ?>>
@@ -88,7 +102,7 @@ if ( ! class_exists( 'NavItemSC' ) ) {
 		/**
 		 * Returns the shortcode's fields.
 		 *
-		 * @author Jim Barnes
+		 * @author Jo Dickson
 		 * @since 1.0.0
 		 *
 		 * @return Array | The shortcode's fields.
@@ -111,7 +125,7 @@ if ( ! class_exists( 'NavItemSC' ) ) {
 				array(
 					'param'   => 'style',
 					'name'    => 'Inline Styles',
-					'desc'    => 'Any additional styles for the container.',
+					'desc'    => 'Any additional styles for the nav item.',
 					'type'    => 'text'
 				)
 			);
@@ -162,7 +176,7 @@ if ( ! class_exists( 'NavLinkSC' ) ) {
 		/**
 		 * Returns the shortcode's fields.
 		 *
-		 * @author Jim Barnes
+		 * @author Jo Dickson
 		 * @since 1.0.0
 		 *
 		 * @return Array | The shortcode's fields.
@@ -194,9 +208,25 @@ if ( ! class_exists( 'NavLinkSC' ) ) {
 				array(
 					'param'   => 'style',
 					'name'    => 'Inline Styles',
-					'desc'    => 'Any additional styles for the container.',
+					'desc'    => 'Any additional styles for the nav link.',
 					'type'    => 'text'
+				),
+				array(
+					'param'   => 'data_toggle',
+					'name'    => 'Data-Toggle',
+					'desc'    => 'Type of toggling functionality the nav link should have.',
+					'type'    => 'select',
+					'options' => $this->data_toggle_options()
 				)
+			);
+		}
+
+		public function data_toggle_options() {
+			return array(
+				''         => '---',
+				'pill'     => 'pill',
+				'tab'      => 'tab',
+				'dropdown' => 'dropdown'
 			);
 		}
 
@@ -210,7 +240,33 @@ if ( ! class_exists( 'NavLinkSC' ) ) {
 			$new_window = filter_var( $atts['new_window'], FILTER_VALIDATE_BOOLEAN );
 			$id         = $atts['id'];
 			$styles     = $atts['style'];
+			$attributes = array();
 			$classes    = array_unique( array_merge( array( 'nav-link' ), explode( ' ', $atts['class'] ) ) );
+
+			// Get any data-attributes, if applicable
+			if ( $atts['data_toggle'] && in_array( $atts['data_toggle'], $this->data_toggle_options() ) ) {
+				$attributes[] = 'data-toggle="' . $atts['data_toggle'] . '"';
+			}
+
+			// Set the link's "role" attribute
+			if ( $href == '' || $href == '#' || $atts['data_toggle'] == 'dropdown' ) {
+				$attributes[] = 'role="button"';
+			}
+			else if ( $atts['data_toggle'] == 'tab' || $atts['data_toggle'] == 'pill' ) {
+				$attributes[] = 'role="tab"';
+			}
+
+			// Set aria attributes as necessary
+			if ( $atts['data_toggle'] == 'dropdown' ) {
+				$attributes[] = 'aria-haspopup="true"';
+				$attributes[] = 'aria-expanded="false"';
+			}
+			else if (
+				( $atts['data_toggle'] == 'tab' || $atts['data_toggle'] == 'pill' )
+				&& ( strlen( $href ) > 1 && substr( $href, 0, 1 ) == '#' )
+			) {
+				$attributes[] = 'aria-controls="' . substr( $href, 1 ) . '"';
+			}
 
 			ob_start();
 		?>
@@ -219,9 +275,133 @@ if ( ! class_exists( 'NavLinkSC' ) ) {
 			<?php if ( $id ) { echo 'id="' . $id . '"'; } ?>
 			<?php if ( $new_window ) { echo 'target="_blank"'; } ?>
 			<?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?>
+			<?php if ( $attributes ) { echo implode( ' ', $attributes ); } ?>
 			>
 				<?php echo do_shortcode( $content ); ?>
 			</a>
+		<?php
+			return ob_get_clean();
+		}
+	}
+}
+
+
+/**
+ * Provides a shortcode for the .tab-content class
+ **/
+if ( ! class_exists( 'TabContentSC' ) ) {
+	class TabContentSC extends ATHENA_SC_Shortcode {
+		public
+			$command = 'tab-content',
+			$name = 'Tab Content',
+			$desc = 'Wraps content in an Athena tab-content wrapper.',
+			$content = true;
+
+		/**
+		 * Returns the shortcode's fields.
+		 *
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 *
+		 * @return Array | The shortcode's fields.
+		 **/
+		public function fields() {
+			return array(
+				array(
+					'param'   => 'class',
+					'name'    => 'CSS Classes',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'style',
+					'name'    => 'Inline Styles',
+					'desc'    => 'Any additional styles for the tab-content element.',
+					'type'    => 'text'
+				)
+			);
+		}
+
+		/**
+		 * Wraps content inside of a div with class .tab-content
+		 **/
+		public function callback( $atts, $content='' ) {
+			$atts = shortcode_atts( $this->defaults(), $atts );
+
+			$styles  = $atts['style'];
+			$classes = array_unique( array_merge( array( 'tab-content' ), explode( ' ', $atts['class'] ) ) );
+
+			ob_start();
+		?>
+			<div class="<?php echo implode( ' ', $classes ); ?>"
+			<?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?>
+			>
+				<?php echo do_shortcode( $content ); ?>
+			</div>
+		<?php
+			return ob_get_clean();
+		}
+	}
+}
+
+
+/**
+ * Provides a shortcode for the .tab-pane class
+ **/
+if ( ! class_exists( 'TabPaneSC' ) ) {
+	class TabPaneSC extends ATHENA_SC_Shortcode {
+		public
+			$command = 'tab-pane',
+			$name = 'Tab Pane',
+			$desc = 'Wraps content in an Athena tab-pane.',
+			$content = true;
+
+		/**
+		 * Returns the shortcode's fields.
+		 *
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 *
+		 * @return Array | The shortcode's fields.
+		 **/
+		public function fields() {
+			return array(
+				array(
+					'param'   => 'class',
+					'name'    => 'CSS Classes',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'id',
+					'name'    => 'ID',
+					'desc'    => 'A unique ID for the tab pane. Required for the pane to be properly activated when toggled.',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'style',
+					'name'    => 'Inline Styles',
+					'desc'    => 'Any additional styles for the tab-pane element.',
+					'type'    => 'text'
+				)
+			);
+		}
+
+		/**
+		 * Wraps content inside of a div with class .tab-pane
+		 **/
+		public function callback( $atts, $content='' ) {
+			$atts = shortcode_atts( $this->defaults(), $atts );
+
+			$id      = $atts['id'];
+			$styles  = $atts['style'];
+			$classes = array_unique( array_merge( array( 'tab-pane' ), explode( ' ', $atts['class'] ) ) );
+
+			ob_start();
+		?>
+			<div class="<?php echo implode( ' ', $classes ); ?>" role="tabpanel" id="<?php echo $id; ?>"
+			<?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?>
+			>
+				<?php echo do_shortcode( $content ); ?>
+			</div>
 		<?php
 			return ob_get_clean();
 		}

--- a/shortcodes/sc-nav.php
+++ b/shortcodes/sc-nav.php
@@ -293,7 +293,7 @@ if ( ! class_exists( 'TabContentSC' ) ) {
 	class TabContentSC extends ATHENA_SC_Shortcode {
 		public
 			$command = 'tab-content',
-			$name = 'Tab Content',
+			$name = 'Nav Tab Content',
 			$desc = 'Wraps content in an Athena tab-content wrapper.',
 			$content = true;
 
@@ -351,7 +351,7 @@ if ( ! class_exists( 'TabPaneSC' ) ) {
 	class TabPaneSC extends ATHENA_SC_Shortcode {
 		public
 			$command = 'tab-pane',
-			$name = 'Tab Pane',
+			$name = 'Nav Tab Pane',
 			$desc = 'Wraps content in an Athena tab-pane.',
 			$content = true;
 

--- a/shortcodes/sc-nav.php
+++ b/shortcodes/sc-nav.php
@@ -25,11 +25,7 @@ if ( ! class_exists( 'NavSC' ) ) {
 					'name'    => 'Element Type',
 					'desc'    => 'Specify the type of element to use for the nav. Unordered lists (ul) are used by default.',
 					'type'    => 'select',
-					'options' => array(
-						'ul'  => 'ul (unordered list)',
-						'nav' => 'nav (semantic navigation element)',
-						'div' => 'div'
-					),
+					'options' => $this->element_type_options(),
 					'default' => 'ul'
 				),
 				array(
@@ -46,6 +42,14 @@ if ( ! class_exists( 'NavSC' ) ) {
 			);
 		}
 
+		public function element_type_options() {
+			return array(
+				'ul'  => 'ul (unordered list)',
+				'nav' => 'nav (semantic navigation element)',
+				'div' => 'div'
+			);
+		}
+
 		/**
 		 * Wraps content inside of an element with class .nav
 		 **/
@@ -54,7 +58,7 @@ if ( ! class_exists( 'NavSC' ) ) {
 
 			$styles  = $atts['style'];
 			$classes = array_unique( array_merge( array( 'nav' ), explode( ' ', $atts['class'] ) ) );
-			$elem    = in_array( $atts['element_type'], array( 'ul', 'nav', 'div' ) ) ? $atts['element_type'] : 'ul';
+			$elem    = in_array( $atts['element_type'], $this->element_type_options() ) ? $atts['element_type'] : $this->defaults( 'element_type' );
 
 			ob_start();
 		?>
@@ -96,10 +100,7 @@ if ( ! class_exists( 'NavItemSC' ) ) {
 					'name'    => 'Element Type',
 					'desc'    => 'Specify the type of element to use for the nav item. List items (li) are used by default.',
 					'type'    => 'select',
-					'options' => array(
-						'li'  => 'li (list item)',
-						'div' => 'div'
-					),
+					'options' => $this->element_type_options(),
 					'default' => 'li'
 				),
 				array(
@@ -116,15 +117,22 @@ if ( ! class_exists( 'NavItemSC' ) ) {
 			);
 		}
 
+		public function element_type_options() {
+			return array(
+				'li'  => 'li (list item)',
+				'div' => 'div'
+			);
+		}
+
 		/**
-		 * Wraps content inside of an element with class .nav
+		 * Wraps content inside of an element with class .nav-item
 		 **/
 		public function callback( $atts, $content='' ) {
 			$atts = shortcode_atts( $this->defaults(), $atts );
 
 			$styles  = $atts['style'];
 			$classes = array_unique( array_merge( array( 'nav-item' ), explode( ' ', $atts['class'] ) ) );
-			$elem    = in_array( $atts['element_type'], array( 'li', 'div' ) ) ? $atts['element_type'] : 'li';
+			$elem    = in_array( $atts['element_type'], $this->element_type_options() ) ? $atts['element_type'] : $this->defaults( 'element_type' );
 
 			ob_start();
 		?>

--- a/shortcodes/sc-nav.php
+++ b/shortcodes/sc-nav.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Provides a shortcode for the .nav class
+ **/
+if ( ! class_exists( 'NavSC' ) ) {
+	class NavSC extends ATHENA_SC_Shortcode {
+		public
+			$command = 'nav',
+			$name = 'Nav',
+			$desc = 'Wraps content in an Athena nav.',
+			$content = true;
+
+		/**
+		 * Returns the shortcode's fields.
+		 *
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 *
+		 * @return Array | The shortcode's fields.
+		 **/
+		public function fields() {
+			return array(
+				array(
+					'param'   => 'element_type',
+					'name'    => 'Element Type',
+					'desc'    => 'Specify the type of element to use for the nav. Unordered lists (ul) are used by default.',
+					'type'    => 'select',
+					'options' => array(
+						'ul'  => 'ul (unordered list)',
+						'nav' => 'nav (semantic navigation element)',
+						'div' => 'div'
+					),
+					'default' => 'ul'
+				),
+				array(
+					'param'   => 'class',
+					'name'    => 'CSS Classes',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'style',
+					'name'    => 'Inline Styles',
+					'desc'    => 'Any additional styles for the container.',
+					'type'    => 'text'
+				)
+			);
+		}
+
+		/**
+		 * Wraps content inside of an element with class .nav
+		 **/
+		public function callback( $atts, $content='' ) {
+			$atts = shortcode_atts( $this->defaults(), $atts );
+
+			$styles  = $atts['style'];
+			$classes = array_unique( array_merge( array( 'nav' ), explode( ' ', $atts['class'] ) ) );
+			$elem    = in_array( $atts['element_type'], array( 'ul', 'nav', 'div' ) ) ? $atts['element_type'] : 'ul';
+
+			ob_start();
+		?>
+			<<?php echo $elem; ?> class="<?php echo implode( ' ', $classes ); ?>"
+			<?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?>
+			>
+				<?php echo do_shortcode( $content ); ?>
+			</<?php echo $elem; ?>>
+		<?php
+			return ob_get_clean();
+		}
+	}
+}
+
+
+/**
+ * Provides a shortcode for the .nav-item class
+ **/
+if ( ! class_exists( 'NavItemSC' ) ) {
+	class NavItemSC extends ATHENA_SC_Shortcode {
+		public
+			$command = 'nav-item',
+			$name = 'Nav Item',
+			$desc = 'Wraps content in an Athena nav-item.',
+			$content = true;
+
+		/**
+		 * Returns the shortcode's fields.
+		 *
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 *
+		 * @return Array | The shortcode's fields.
+		 **/
+		public function fields() {
+			return array(
+				array(
+					'param'   => 'element_type',
+					'name'    => 'Element Type',
+					'desc'    => 'Specify the type of element to use for the nav item. List items (li) are used by default.',
+					'type'    => 'select',
+					'options' => array(
+						'li'  => 'li (list item)',
+						'div' => 'div'
+					),
+					'default' => 'li'
+				),
+				array(
+					'param'   => 'class',
+					'name'    => 'CSS Classes',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'style',
+					'name'    => 'Inline Styles',
+					'desc'    => 'Any additional styles for the container.',
+					'type'    => 'text'
+				)
+			);
+		}
+
+		/**
+		 * Wraps content inside of an element with class .nav
+		 **/
+		public function callback( $atts, $content='' ) {
+			$atts = shortcode_atts( $this->defaults(), $atts );
+
+			$styles  = $atts['style'];
+			$classes = array_unique( array_merge( array( 'nav-item' ), explode( ' ', $atts['class'] ) ) );
+			$elem    = in_array( $atts['element_type'], array( 'li', 'div' ) ) ? $atts['element_type'] : 'li';
+
+			ob_start();
+		?>
+			<<?php echo $elem; ?> class="<?php echo implode( ' ', $classes ); ?>"
+			<?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?>
+			>
+				<?php echo do_shortcode( $content ); ?>
+			</<?php echo $elem; ?>>
+		<?php
+			return ob_get_clean();
+		}
+	}
+}
+
+
+/**
+ * Provides a shortcode for the .nav-link class
+ **/
+if ( ! class_exists( 'NavLinkSC' ) ) {
+	class NavLinkSC extends ATHENA_SC_Shortcode {
+		public
+			$command = 'nav-link',
+			$name = 'Nav Link',
+			$desc = 'Wraps content in an Athena nav-link.',
+			$content = true;
+
+		/**
+		 * Returns the shortcode's fields.
+		 *
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 *
+		 * @return Array | The shortcode's fields.
+		 **/
+		public function fields() {
+			return array(
+				array(
+					'param'   => 'href',
+					'name'    => 'Nav Link URL',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'new_window',
+					'name'    => 'If checked, opens link in a new window.',
+					'type'    => 'checkbox',
+					'default' => false
+				),
+				array(
+					'param'   => 'class',
+					'name'    => 'CSS Classes',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'id',
+					'name'    => 'ID',
+					'desc'    => 'ID attribute for the link. Must be unique.',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'style',
+					'name'    => 'Inline Styles',
+					'desc'    => 'Any additional styles for the container.',
+					'type'    => 'text'
+				)
+			);
+		}
+
+		/**
+		 * Wraps content inside of a link with class .nav-link
+		 **/
+		public function callback( $atts, $content='' ) {
+			$atts = shortcode_atts( $this->defaults(), $atts );
+
+			$href       = $atts['href'];
+			$new_window = filter_var( $atts['new_window'], FILTER_VALIDATE_BOOLEAN );
+			$id         = $atts['id'];
+			$styles     = $atts['style'];
+			$classes    = array_unique( array_merge( array( 'nav-link' ), explode( ' ', $atts['class'] ) ) );
+
+			ob_start();
+		?>
+			<a class="<?php echo implode( ' ', $classes ); ?>"
+			<?php if ( $href ) { echo 'href="' . $href . '"'; } ?>
+			<?php if ( $id ) { echo 'id="' . $id . '"'; } ?>
+			<?php if ( $new_window ) { echo 'target="_blank"'; } ?>
+			<?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?>
+			>
+				<?php echo do_shortcode( $content ); ?>
+			</a>
+		<?php
+			return ob_get_clean();
+		}
+	}
+}

--- a/shortcodes/shortcodes.php
+++ b/shortcodes/shortcodes.php
@@ -7,3 +7,4 @@ include_once 'sc-row.php';
 include_once 'sc-col.php';
 
 include_once 'sc-badge.php';
+include_once 'sc-nav.php';


### PR DESCRIPTION
Added shortcodes for basic navs, tab navs, pill navs, and tab panes.  (Note, this does _not_ include navbars).  

Each base class is given a shortcode for ease of use and flexibility.  I've tried to handle the addition of accessibility-related attributes behind-the-scenes as much as possible for simplicity.

The following new shortcodes are included in this branch:
[nav]
[nav-item]
[nav-link]
[tab-content]
[tab-pane]

Example of a basic, no-frills nav:
```
[nav]
[nav-item][nav-link href="/" class="active"]Active[/nav-link][/nav-item]
[nav-item][nav-link href="/path/to/link/"]Link[/nav-link][/nav-item]
[nav-item][nav-link href="/path/to/link/" class="disabled"]Disabled[/nav-link][/nav-item]
[/nav]
```
would generate:
```
<ul class="nav">
<li class="nav-item"><a class="nav-link active" href="/">Active</a></li>
<li class="nav-item"><a class="nav-link" href="/path/to/link/">Link</a></li>
<li class="nav-item"><a class="nav-link disabled" href="/path/to/link/">Disabled</a></li>
</ul>
```

The following is also valid, will visually appear the same as the above example, and generates simpler markup.  (Valid element_types include 'ul', 'div' and 'nav'):
```
[nav element_type="div"]
[nav-link href="/" class="active"]Active[/nav-link]
[nav-link href="/path/to/link/"]Link[/nav-link]
[nav-link href="/path/to/link/" class="disabled"]Disabled[/nav-link]
[/nav]
```
which generates:
```
<div class="nav">
<a class="nav-link active" href="/">Active</a>
<a class="nav-link" href="/path/to/link/">Link</a>
<a class="nav-link disabled" href="/path/to/link/">Disabled</a>
</div>
```

Nav links are able to toggle tab panes or dropdowns; the necessary attribute handling is in place for dropdown nav-links in this branch, but since there's not a dropdown shortcode yet, we won't be able to do much with this option for now.