### PR TITLE
ACF wysiwyg field filters

### DIFF
--- a/athena-shortcodes.php
+++ b/athena-shortcodes.php
@@ -45,10 +45,10 @@ if ( ! function_exists( 'athena_sc_init' ) ) {
 		// Update the_content to strip excess <p></p> and <br> insertion around
 		// Athena shortcodes.
 		add_filter( 'the_content', array( 'ATHENA_SC_Config', 'format_shortcode_output' ), 10, 1 );
-		// Hook into ACF's custom acf_the_content hook to strip excess
+		// Hook into ACF's custom field filtering hooks to strip excess
 		// <p></p> and <br> insertion around shortcodes in WYSIWYG fields.
 		if ( class_exists( 'acf' ) ) {
-			add_filter( 'acf_the_content', array( 'ATHENA_SC_Config', 'format_shortcode_output' ), 10, 1 );
+			add_filter( 'acf/format_value/type=wysiwyg', array( 'ATHENA_SC_Config', 'format_acf_wysiwyg_output' ), 99, 3 );
 		}
 		// Register our shortcodes.
 		add_action( 'init', array( 'ATHENA_SC_Config', 'register_shortcodes' ) );

--- a/athena-shortcodes.php
+++ b/athena-shortcodes.php
@@ -45,6 +45,11 @@ if ( ! function_exists( 'athena_sc_init' ) ) {
 		// Update the_content to strip excess <p></p> and <br> insertion around
 		// Athena shortcodes.
 		add_filter( 'the_content', array( 'ATHENA_SC_Config', 'format_shortcode_output' ), 10, 1 );
+		// Hook into ACF's custom acf_the_content hook to strip excess
+		// <p></p> and <br> insertion around shortcodes in WYSIWYG fields.
+		if ( class_exists( 'acf' ) ) {
+			add_filter( 'acf_the_content', array( 'ATHENA_SC_Config', 'format_shortcode_output' ), 10, 1 );
+		}
 		// Register our shortcodes.
 		add_action( 'init', array( 'ATHENA_SC_Config', 'register_shortcodes' ) );
 

--- a/includes/athena-sc-config.php
+++ b/includes/athena-sc-config.php
@@ -104,5 +104,17 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 			$rep = preg_replace( "/(<p>)?\[\/($block)](<\/p>|<br \/>)?/", "[/$2]", $rep );
 			return $rep;
 		}
+
+		/**
+		 * Strip out <p></p> and <br> from inner shortcode contents within ACF
+		 * WYSIWYG field contents.
+		 *
+		 * There is probably a less janky way of doing this that doesn't
+		 * involve re-fetching the field value, but this works at least
+		 **/
+		public static function format_acf_wysiwyg_output( $content, $post_id, $field ) {
+			$value_raw = acf_get_value( $post_id, $field );
+			return apply_filters( 'the_content', $value_raw );
+		}
 	}
 }


### PR DESCRIPTION
So, ACF's WYSIWYG fields apparently have their own weird stack of content filters that are applied to the field value when returned using `get_field()`, instead of using just WP's `the_content` filter like you'd expect.  This means that our `<p>` and `<br>` tag filters won't take effect on ACF WYSIWYG fields that include shortcodes, resulting in undesirable excess whitespace around and inside the shortcode contents.

Unfortunately I was not able to hook in to ACF's provided hook [`acf/format_value/type=wysiwyg`](https://www.advancedcustomfields.com/resources/acf-format_value/) and get the correct results--there seems to be some other content filtering happening sooner, and I'm having trouble finding the right place during the whole `get_field()` process to hook into.

To get around these issues, this branch introduces a really stupid filter that re-fetches the raw field value and returns it instead, with `the_content` filtering applied.  If anybody else wants to take a stab at this and see if they can get a hook going that doesn't require having to re-fetch the value, please feel free--if not, this code should do what we need it to do.