### PR TITLE
Media backgrounds - first pass

### DIFF
--- a/includes/athena-sc-config.php
+++ b/includes/athena-sc-config.php
@@ -63,6 +63,8 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 				'CollapseSC',
 				'CollapseToggleSC',
 				'JumbotronSC',
+				'MediaBackgroundContainerSC',
+				'MediaBackgroundSC',
 				'ModalSC',
 				'ModalHeaderSC',
 				'ModalFooterSC',

--- a/shortcodes/sc-media-background.php
+++ b/shortcodes/sc-media-background.php
@@ -9,7 +9,8 @@ if ( ! class_exists( 'MediaBackgroundContainerSC' ) ) {
 			$name = 'Media Background Container',
 			$desc = 'Creates a media background container.',
 			$content = true,
-			$preview = false;
+			$preview = false,
+			$group = 'Athena Framework - Media Backgrounds';
 
 		/**
 		 * Returns the shortcode's fields.
@@ -122,7 +123,8 @@ if ( ! class_exists( 'MediaBackgroundContainerSC' ) ) {
 			$name = 'Media Background',
 			$desc = 'Creates a media background. Immediate child images and video are auto-detected and used as media background(s).',
 			$content = true,
-			$preview = false;
+			$preview = false,
+			$group = 'Athena Framework - Media Backgrounds';
 
 		/**
 		 * Returns the shortcode's fields.

--- a/shortcodes/sc-media-background.php
+++ b/shortcodes/sc-media-background.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Provides a shortcode for media background containers.
+ **/
+if ( ! class_exists( 'MediaBackgroundContainerSC' ) ) {
+	class MediaBackgroundContainerSC extends ATHENA_SC_Shortcode {
+		public
+			$command = 'media-background-container',
+			$name = 'Media Background Container',
+			$desc = 'Creates a media background container.',
+			$content = true,
+			$preview = false;
+
+		/**
+		 * Returns the shortcode's fields.
+		 *
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 *
+		 * @return Array | The shortcode's fields.
+		 **/
+		public function fields() {
+			return array(
+				array(
+					'param'   => 'element_type',
+					'name'    => 'Element Type',
+					'desc'    => 'Specify the type of element to use. Divs are used by default.',
+					'type'    => 'select',
+					'options' => $this->element_type_options(),
+					'default' => 'div'
+				),
+				array(
+					'param'   => 'href',
+					'name'    => 'Link (for link elements)',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'new_window',
+					'name'    => 'Open link in a new window (for link elements)',
+					'type'    => 'checkbox',
+					'default' => false
+				),
+				array(
+					'param'   => 'class',
+					'name'    => 'CSS Classes',
+					'desc'    => 'Separate each class with a single space. Refer to the Athena Framework documentation for available classes.',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'id',
+					'name'    => 'ID',
+					'desc'    => 'ID attribute for the element. Must be unique.',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'style',
+					'name'    => 'Inline Styles',
+					'desc'    => 'Any additional styles for the element.',
+					'type'    => 'text'
+				)
+			);
+		}
+
+		public function element_type_options() {
+			return array(
+				'div'     => 'div',
+				'section' => 'section',
+				'aside'   => 'aside',
+				'a'       => 'a'
+			);
+		}
+
+		/**
+		 * Wraps content inside of a .media-background-container and applies
+		 * necessary classes to inner img/video
+		 **/
+		public function callback( $atts, $content='' ) {
+			$atts = shortcode_atts( $this->defaults(), $atts );
+
+			$href         = $atts['element_type'] === 'a' ? $atts['href'] : '';
+			$new_window   = $atts['element_type'] === 'a' ? filter_var( $atts['new_window'], FILTER_VALIDATE_BOOLEAN ) : false;
+			$id           = $atts['id'];
+			$element_type = array_key_exists( $atts['element_type'], $this->element_type_options() ) ? $atts['element_type'] : $this->defaults( 'element_type' );
+			$styles       = $atts['style'];
+			$attributes   = array();
+			$classes      = array( 'media-background-container' );
+			$content_formatted = do_shortcode( $content );
+
+			if ( $atts['class'] ) {
+				$classes = array_unique( array_merge( $classes, explode( ' ', $atts['class'] ) ) );
+			}
+
+			if ( $element_type === 'a' && !$href ) {
+				$attributes[] = 'tabindex="0"';
+			}
+
+			ob_start();
+		?>
+			<<?php echo $element_type; ?> class="<?php echo implode( ' ', $classes ); ?>"
+			<?php if ( $href ) { echo 'href="' . $href . '"'; } ?>
+			<?php if ( $id ) { echo 'id="' . $id . '"'; } ?>
+			<?php if ( $new_window ) { echo 'target="_blank"'; } ?>
+			<?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?>
+			<?php if ( $attributes ) { echo implode( ' ', $attributes ); } ?>
+			>
+				<?php echo $content_formatted; ?>
+			</<?php echo $element_type; ?>>
+		<?php
+			return ob_get_clean();
+		}
+	}
+}
+
+
+/**
+ * Provides a shortcode for media backgrounds.
+ **/
+ if ( ! class_exists( 'MediaBackgroundSC' ) ) {
+	class MediaBackgroundSC extends ATHENA_SC_Shortcode {
+		public
+			$command = 'media-background',
+			$name = 'Media Background',
+			$desc = 'Creates a media background. Immediate child images and video are auto-detected and used as media background(s).',
+			$content = true,
+			$preview = false;
+
+		/**
+		 * Returns the shortcode's fields.
+		 *
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 *
+		 * @return Array | The shortcode's fields.
+		 **/
+		public function fields() {
+			return array(
+				array(
+					'param'   => 'object_fit',
+					'name'    => 'Object Fit',
+					'desc'    => 'How the inner media background should be resized within the media background container.',
+					'type'    => 'select',
+					'options' => $this->object_fit_options(),
+					'default' => 'object-fit-cover'
+				),
+				array(
+					'param'   => 'class',
+					'name'    => 'CSS Classes',
+					'desc'    => 'Separate each class with a single space. Refer to the Athena Framework documentation for available classes.',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'id',
+					'name'    => 'ID',
+					'desc'    => 'ID attribute for the inner element. Must be unique.',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'style',
+					'name'    => 'Inline Styles',
+					'desc'    => 'Any additional styles for the inner element.',
+					'type'    => 'text'
+				)
+			);
+		}
+
+		public function object_fit_options() {
+			return array(
+				'object-fit-contain'    => 'contain',
+				'object-fit-cover'      => 'cover',
+				'object-fit-fill'       => 'fill',
+				'object-fit-none'       => 'none (unset an existing object-fit rule)',
+				'object-fit-scale-down' => 'scale-down'
+			);
+		}
+
+		/**
+		 * Wraps content inside of a .media-background and applies
+		 * necessary classes to inner img/picture/video
+		 **/
+		public function callback( $atts, $content='' ) {
+			$atts = shortcode_atts( $this->defaults(), $atts );
+
+			$id         = $atts['id'];
+			$object_fit = array_key_exists( $atts['object_fit'], $this->object_fit_options() ) ? $atts['object_fit'] : $this->defaults( 'object_fit' );
+			$styles     = $atts['style'];
+			$classes    = array( 'media-background', $object_fit );
+
+			if ( $atts['class'] ) {
+				$classes = array_unique( array_merge( $classes, explode( ' ', $atts['class'] ) ) );
+			}
+
+			$content_formatted = do_shortcode( $content );
+			$has_valid_media_bg = false;
+
+			// Match any one inner <img> (either on its own, or as a <picture>
+			// fallback)
+			if ( preg_match( '/(<p>)?(<a [^>]+>)?<img [^>]+>(<\/a>)?(<\/p>)?/', $content_formatted, $match ) ) {
+				$match_full = $match[0];
+				$p_start    = $match[1];
+				$a_start    = $match[2];
+				$a_end      = $match[3];
+				$p_end      = $match[4];
+				$match_filtered = $match_full;
+
+				// Strip wrapper <p>'s and <a>'s from inner elems
+				$match_filtered = str_replace( array( $p_start, $a_start, $a_end, $p_end ), '', $match_filtered );
+
+				// Apply extra classes
+				if ( preg_match( '/class\=[\"|\']([^\"|\']+)[\"|\']/', $match_filtered, $class_matches ) ) {
+					$elem_classes = array_merge( explode( ' ', $class_matches[1] ), $classes );
+					$match_filtered = str_replace( $class_matches[0], 'class="' . implode( ' ', $elem_classes ) . '"', $match_filtered );
+				}
+				else {
+					$match_filtered = str_replace( '<img ', '<img class="' . implode( ' ', $classes ) . '" ', $match_filtered );
+				}
+
+				// Apply extra styles
+				if ( $styles ) {
+					if ( preg_match( '/style\=[\"|\']([^\"|\']+)[\"|\']/', $match_filtered, $style_matches ) ) {
+						$match_filtered = str_replace( $style_matches[0], 'style="' . $styles . '"', $match_filtered );
+					}
+					else {
+						$match_filtered = str_replace( '<img ', '<img style="' . $styles . '" ', $match_filtered );
+					}
+				}
+
+				// Apply ID if this is a standalone img
+				if ( $id && strpos( $content_formatted, '<picture' ) === false ) {
+					if ( preg_match( '/id\=[\"|\']([^\"|\']+)[\"|\']/', $match_filtered, $id_match ) ) {
+						$match_filtered = str_replace( $id_match[0], 'id="' . $id . '"', $match_filtered );
+					}
+					else {
+						$match_filtered = str_replace( '<img ', '<img id="' . $id . '" ', $match_filtered );
+					}
+				}
+
+				$content_formatted = str_replace( $match_full, $match_filtered, $content_formatted );
+				$has_valid_media_bg = true;
+			}
+
+			if ( preg_match( '/<picture [^>]+>.*<\/picture>/', $content_formatted, $match ) ) {
+				// TODO
+				// var_dump( $match );
+				$has_valid_media_bg = true;
+			}
+
+			if ( preg_match( '/<video [^>]+>.*<\/video>/', $content_formatted, $match ) ) {
+				// TODO
+				// var_dump( $match );
+				$has_valid_media_bg = true;
+			}
+
+			// Return the media background, or an empty string if no inner
+			// contents are valid media backgrounds
+			return $has_valid_media_bg ? $content_formatted : '';
+		}
+	}
+}

--- a/shortcodes/sc-media-background.php
+++ b/shortcodes/sc-media-background.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'MediaBackgroundContainerSC' ) ) {
 		/**
 		 * Returns the shortcode's fields.
 		 *
-		 * @author Jim Barnes
+		 * @author Jo Dickson
 		 * @since 1.0.0
 		 *
 		 * @return Array | The shortcode's fields.
@@ -128,7 +128,7 @@ if ( ! class_exists( 'MediaBackgroundContainerSC' ) ) {
 		/**
 		 * Returns the shortcode's fields.
 		 *
-		 * @author Jim Barnes
+		 * @author Jo Dickson
 		 * @since 1.0.0
 		 *
 		 * @return Array | The shortcode's fields.

--- a/shortcodes/sc-media-background.php
+++ b/shortcodes/sc-media-background.php
@@ -72,8 +72,7 @@ if ( ! class_exists( 'MediaBackgroundContainerSC' ) ) {
 		}
 
 		/**
-		 * Wraps content inside of a .media-background-container and applies
-		 * necessary classes to inner img/video
+		 * Wraps content inside of a .media-background-container
 		 **/
 		public function callback( $atts, $content='' ) {
 			$atts = shortcode_atts( $this->defaults(), $atts );

--- a/shortcodes/sc-media-background.php
+++ b/shortcodes/sc-media-background.php
@@ -10,7 +10,7 @@ if ( ! class_exists( 'MediaBackgroundContainerSC' ) ) {
 			$desc = 'Creates a media background container.',
 			$content = true,
 			$preview = false,
-			$group = 'Athena Framework - Media Backgrounds';
+			$group = 'Athena Framework - Utilities';
 
 		/**
 		 * Returns the shortcode's fields.
@@ -124,7 +124,7 @@ if ( ! class_exists( 'MediaBackgroundContainerSC' ) ) {
 			$desc = 'Creates a media background. Immediate child images and video are auto-detected and used as media background(s).',
 			$content = true,
 			$preview = false,
-			$group = 'Athena Framework - Media Backgrounds';
+			$group = 'Athena Framework - Utilities';
 
 		/**
 		 * Returns the shortcode's fields.

--- a/shortcodes/shortcodes.php
+++ b/shortcodes/shortcodes.php
@@ -12,5 +12,6 @@ include_once 'sc-card.php';
 include_once 'sc-close.php';
 include_once 'sc-collapse.php';
 include_once 'sc-jumbotron.php';
+include_once 'sc-media-background.php';
 include_once 'sc-modal.php';
 include_once 'sc-nav.php';


### PR DESCRIPTION
This branch adds two new shortcodes: [media-background-container] and [media-background].  

[media-background-container] is a simple wrapper element generator for the .media-background-container class.  You don't need to use it if you're able to just apply the .media-background-container class to an existing parent element (e.g. jumbotrons); it exists primarily for more advanced uses, such as on block-style links, and for the sake of having both media background utility classes covered with shortcode support.

[media-background] is set up to search its inner contents for valid media backgrounds, extract the first one found, apply any necessary attributes to it, and return it.  If no valid media backgrounds are found, an empty `<div>` is returned with the provided classes/id/styles/object-fit settings (which provides support for things like semi-transparent divs with hover transitions, for example).  Searching for inner shortcode contents allows users to provide images/videos and modify them using native WP WYSIWYG tools, and should make it easier for us to add support for other elements in the future (such as `<picture>`).

Basic usage:

```
[media-background-container]
  [media-background]
    <img src="...">
  [/media-background]
  [media-background]
    ...
  [/media-background]
  Inner contents here...
[/media-background-container]
```

Currently the supported media background types are `<img>` and `<video>`; there are intentional TODOs in this branch that reference adding support for `<picture>`.