### PR TITLE
Column modifier class updates

### DIFF
--- a/shortcodes/sc-col.php
+++ b/shortcodes/sc-col.php
@@ -196,21 +196,11 @@ if ( ! class_exists( 'ColSC' ) ) {
 					$field_val = $atts[$field_key];
 
 					if ( isset( $field_val ) && $field_val !== '' ) {
-						$modifier   = str_replace( '_', '', $suffix );
-						$breakpoint = $prefix == 'xs' ? '' : '-' . $prefix;
+						$modifier   = $suffix === '' ? 'col' : str_replace( '_', '', $suffix );
+						$breakpoint = $prefix === 'xs' ? '' : '-' . $prefix;
 						$size       = ( in_array( $field_val, array( '', 'none' ), true ) ) ? '' : '-' . $field_val;
 
-						// This is a offset, pull or push class
-						if ( $suffix !== '' ) {
-							$classes[] = $modifier . $breakpoint . $size;
-						}
-						// This is a standard col class
-						else {
-							if ( $modifier !== '' ) {
-								$modifier = '-' . $modifier;
-							}
-							$classes[] = 'col' . $breakpoint . $modifier . $size;
-						}
+						$classes[] = $modifier . $breakpoint . $size;
 					}
 				}
 			}

--- a/shortcodes/sc-col.php
+++ b/shortcodes/sc-col.php
@@ -195,7 +195,7 @@ if ( ! class_exists( 'ColSC' ) ) {
 					$field_key = $prefix.$suffix;
 					$field_val = $atts[$field_key];
 
-					if ( $field_val && $field_val !== '' ) {
+					if ( isset( $field_val ) && $field_val !== '' ) {
 						$modifier   = str_replace( '_', '', $suffix );
 						$breakpoint = $prefix == 'xs' ? '' : '-' . $prefix;
 						$size       = ( in_array( $field_val, array( '', 'none' ), true ) ) ? '' : '-' . $field_val;


### PR DESCRIPTION
Fixed an issue that prevented column modifiers such as `.offset-md-0` from being set properly (PHP evaluates the string "0" as `false`, so the boolean check for `$field_val` on line 198 wasn't working as intended).

Also simplified how column-related classes are built, specifically by removing some redundant logic for `.col-` classes.