### PR TITLE
Block link shortcode

### DIFF
--- a/includes/athena-sc-config.php
+++ b/includes/athena-sc-config.php
@@ -47,6 +47,7 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 				'ColSC',
 				'AccordionSC',
 				'BadgeSC',
+				'BlockLinkSC',
 				'ButtonSC',
 				'CardSC',
 				'CardHeaderSC',

--- a/shortcodes/sc-block-link.php
+++ b/shortcodes/sc-block-link.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Provides a shortcode for media background containers.
+ **/
+if ( ! class_exists( 'BlockLinkSC' ) ) {
+	class BlockLinkSC extends ATHENA_SC_Shortcode {
+		public
+			$command = 'block-link',
+			$name = 'Block Link',
+			$desc = 'Inserts a generic link. Useful for wrapping block-level content in a link that would otherwise get stripped by the WYSIWYG editor.',
+			$content = true,
+			$preview = false,
+			$group = 'Athena Framework - Utilities';
+
+		/**
+		 * Returns the shortcode's fields.
+		 *
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 *
+		 * @return Array | The shortcode's fields.
+		 **/
+		public function fields() {
+			return array(
+				array(
+					'param'   => 'href',
+					'name'    => 'Link location',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'new_window',
+					'name'    => 'Open link in a new window',
+					'type'    => 'checkbox',
+					'default' => false
+				),
+				array(
+					'param'   => 'class',
+					'name'    => 'CSS Classes',
+					'desc'    => 'Separate each class with a single space. Refer to the Athena Framework documentation for available classes.',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'id',
+					'name'    => 'ID',
+					'desc'    => 'ID attribute for the element. Must be unique.',
+					'type'    => 'text'
+				),
+				array(
+					'param'   => 'style',
+					'name'    => 'Inline Styles',
+					'desc'    => 'Any additional styles for the element.',
+					'type'    => 'text'
+				)
+			);
+		}
+
+		/**
+		 * Wraps content inside of a generic link
+		 **/
+		public function callback( $atts, $content='' ) {
+			$atts = shortcode_atts( $this->defaults(), $atts );
+
+			$href         = $atts['href'];
+			$new_window   = filter_var( $atts['new_window'], FILTER_VALIDATE_BOOLEAN );
+			$id           = $atts['id'];
+			$styles       = $atts['style'];
+			$attributes   = array();
+			$classes      = $atts['class'];
+
+			if ( !$href ) {
+				$attributes[] = 'tabindex="0"';
+			}
+
+			ob_start();
+		?>
+			<a class="<?php echo $classes; ?>"
+			<?php if ( $href ) { echo 'href="' . $href . '"'; } ?>
+			<?php if ( $id ) { echo 'id="' . $id . '"'; } ?>
+			<?php if ( $new_window ) { echo 'target="_blank"'; } ?>
+			<?php if ( $styles ) { echo 'style="' . $styles . '"'; } ?>
+			<?php if ( $attributes ) { echo implode( ' ', $attributes ); } ?>
+			>
+				<?php echo do_shortcode( $content ); ?>
+			</a>
+		<?php
+			return ob_get_clean();
+		}
+	}
+}

--- a/shortcodes/shortcodes.php
+++ b/shortcodes/shortcodes.php
@@ -7,6 +7,7 @@ include_once 'sc-row.php';
 include_once 'sc-col.php';
 
 include_once 'sc-badge.php';
+include_once 'sc-block-link.php';
 include_once 'sc-button.php';
 include_once 'sc-card.php';
 include_once 'sc-close.php';


### PR DESCRIPTION
This isn't a new thing, but TinyMCE complains about block-level elements being nested inside of `<a>` tags specifically, so I added this as a quick workaround to make other framework shortcodes a little easier to use.