### PR TITLE
Automatic opt-in class insertion in WYSIWYG editor; bug fixes

### DIFF
--- a/includes/athena-sc-config.php
+++ b/includes/athena-sc-config.php
@@ -70,6 +70,15 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 										  posts/pages).",
 					'field_type'      => 'checkbox'
 				) ),
+				new ATHENA_SC_Plugin_Option( self::$option_prefix . 'enable_optin_classes', array(
+					'default'         => true,
+					'format_callback' => 'wp_validate_boolean',
+					'field_title'     => 'Enable automatic insertion of opt-in content classes',
+					'field_desc'      => "When checked, CSS classes for opt-in content styles will be added to elements automatically
+										  in the TinyMCE editor.  Currently, this includes <code>.table</code> for tables and
+										  <code>.blockquote</code> for blockquotes.",
+					'field_type'      => 'checkbox'
+				) ),
 				new ATHENA_SC_Plugin_Option( self::$option_prefix . 'enable_responsive_embeds', array(
 					'default'         => false,
 					'format_callback' => 'wp_validate_boolean',
@@ -179,7 +188,7 @@ if ( ! class_exists( 'ATHENA_SC_Config' ) ) {
 		public static function add_option_filters() {
 			foreach ( self::get_options() as $option ) {
 				// Apply formatting to returned option values
-				add_filter( 'option_{$option->option_name}', array( 'ATHENA_SC_Config', 'format_option' ), 10, 2 );
+				add_filter( "option_{$option->option_name}", array( 'ATHENA_SC_Config', 'format_option' ), 10, 2 );
 			}
 		}
 

--- a/includes/athena-sc-tinymce-config.php
+++ b/includes/athena-sc-tinymce-config.php
@@ -73,7 +73,7 @@ if ( ! class_exists( 'ATHENA_SC_TinyMCE_Config' ) ) {
 						if ( !$option['title'] ) { $option['title'] = $option['classes']; }
 					}
 					else {
-						break;
+						continue;
 					}
 
 					$option = array_filter( $option );
@@ -95,10 +95,18 @@ if ( ! class_exists( 'ATHENA_SC_TinyMCE_Config' ) ) {
 
 			$new_style_formats = array();
 
+			// Define opt-in element classes if automatic insertion of
+			// these classes is disabled:
+			$blockquote_optin_class = $table_optin_class = null;
+			if ( ! get_option( 'athena_sc_enable_optin_classes' ) ) {
+				$blockquote_optin_class = array( 'block' => 'blockquote', 'classes' => 'blockquote', 'selector' => 'blockquote' );
+				$table_optin_class      = array( 'classes' => 'table', 'selector' => 'table' );
+			}
+
 			// Text, list formatting options
 			$new_style_formats = array(
 				self::get_format( 'Blockquote Styles', array(
-					array( 'block' => 'blockquote', 'classes' => 'blockquote', 'selector' => 'blockquote' ),
+					$blockquote_optin_class,
 					array( 'block' => 'blockquote', 'classes' => 'blockquote-reverse', 'selector' => 'blockquote' ),
 					array( 'block' => 'blockquote', 'classes' => 'blockquote-quotation', 'selector' => 'blockquote' ),
 					array( 'block' => 'blockquote', 'classes' => 'blockquote-quotation-inverse', 'selector' => 'blockquote' ),
@@ -176,7 +184,7 @@ if ( ! class_exists( 'ATHENA_SC_TinyMCE_Config' ) ) {
 					'hidden-print'
 				) ),
 				self::get_format( 'Table Styles', array(
-					array( 'classes' => 'table', 'selector' => 'table' ),
+					$table_optin_class,
 					array( 'classes' => 'table-responsive', 'selector' => 'table' ),
 					array( 'classes' => 'table-striped', 'selector' => 'table' ),
 					array( 'classes' => 'table-bordered', 'selector' => 'table' ),
@@ -268,33 +276,47 @@ if ( ! class_exists( 'ATHENA_SC_TinyMCE_Config' ) ) {
 		}
 
 		public static function get_init_instance_callback() {
-			ob_start();
-		?>
-		function (editor) {
-			editor.on('NodeChange', function (e) {
-				var elems = e.parents;
+			$callback     = '';
+			$has_callback = false;
 
-				elems.forEach(function(elem) {
-					/* Tables */
-					if (elem.tagName.toLowerCase() === 'table') {
-						elem.classList.add('table');
-					}
+			if ( get_option( 'athena_sc_enable_optin_classes' ) === true ) {
+				$has_callback = true;
+			}
 
-					/* Blockquotes */
-					if (elem.tagName.toLowerCase() === 'blockquote') {
-						elem.classList.add('blockquote');
-					}
+			if ( $has_callback ):
+				ob_start();
+			?>
+			function (editor) {
+				editor.on('NodeChange', function (e) {
+					var elems = e.parents;
+
+					elems.forEach(function(elem) {
+						/* Tables */
+						if (elem.tagName.toLowerCase() === 'table') {
+							elem.classList.add('table');
+						}
+
+						/* Blockquotes */
+						if (elem.tagName.toLowerCase() === 'blockquote') {
+							elem.classList.add('blockquote');
+						}
+					});
 				});
-			});
-		}
-		<?php
-			return trim( ob_get_clean() );
+			}
+			<?php
+				$callback = trim( ob_get_clean() );
+			endif;
+
+			return $callback;
 		}
 
 		public static function register_settings( $settings ) {
 			$settings['block_formats'] = self::get_block_formats( isset( $settings['block_formats'] ) ? $settings['block_formats'] : false );
 			$settings['style_formats'] = self::get_style_formats( isset( $settings['style_formats'] ) ? $settings['style_formats'] : false );
-			$settings['init_instance_callback'] = self::get_init_instance_callback();
+
+			if ( $init_instance_callback = self::get_init_instance_callback() ) {
+				$settings['init_instance_callback'] = $init_instance_callback;
+			}
 
 			return $settings;
 		}

--- a/includes/athena-sc-tinymce-config.php
+++ b/includes/athena-sc-tinymce-config.php
@@ -267,9 +267,34 @@ if ( ! class_exists( 'ATHENA_SC_TinyMCE_Config' ) ) {
 			return json_encode( array_merge( $style_formats, $new_style_formats ) );
 		}
 
+		public static function get_init_instance_callback() {
+			ob_start();
+		?>
+		function (editor) {
+			editor.on('NodeChange', function (e) {
+				var elems = e.parents;
+
+				elems.forEach(function(elem) {
+					/* Tables */
+					if (elem.tagName.toLowerCase() === 'table') {
+						elem.classList.add('table');
+					}
+
+					/* Blockquotes */
+					if (elem.tagName.toLowerCase() === 'blockquote') {
+						elem.classList.add('blockquote');
+					}
+				});
+			});
+		}
+		<?php
+			return trim( ob_get_clean() );
+		}
+
 		public static function register_settings( $settings ) {
 			$settings['block_formats'] = self::get_block_formats( isset( $settings['block_formats'] ) ? $settings['block_formats'] : false );
 			$settings['style_formats'] = self::get_style_formats( isset( $settings['style_formats'] ) ? $settings['style_formats'] : false );
+			$settings['init_instance_callback'] = self::get_init_instance_callback();
 
 			return $settings;
 		}


### PR DESCRIPTION
<!---
Thank you for contributing to the Athena Shortcodes Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Athena-Shortcodes-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Enhancements:
- Added the ability to let TinyMCE automatically add opt-in content classes (`.table` on `<table>`s, `.blockquote` on `<blockquote>`s.  By default this is enabled, but it can be disabled via plugin settings in case folks run into conflicts with third-party markup or something.
- Updated the "Formats" dropdown in the WYSIWYG editor to exclude `.table` and `.blockquote` classes when automatic opt-in class insertion is enabled.

Bug fixes:
- Fixed non-functional `option_{$option->option_name}` filters.  Plugin options are now properly formatted when returned via `get_option()`.
- Replaced `break` with `continue` in `ATHENA_SC_TinyMCE_Config::get_format_options()` to allow null format options to be passed in without breaking all other format options.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #57 

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
